### PR TITLE
dynamic update of server pool

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.20.2
+          go-version: 1.20.3
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,6 @@ linters:
     - asasalint
     - asciicheck
     - bidichk
-    - bodyclose
     - containedctx
     - contextcheck
       #    - cyclop

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"github.com/pelageech/BDUTS/config"
 	"io"
 	"log"
 	"net"
@@ -28,6 +29,19 @@ func NewBackend(url *url.URL, healthCheckTimeout time.Duration, maxRequests int3
 		alive:                 false,
 		requestChan:           c,
 	}
+}
+
+func NewBackendConfig(server config.ServerConfig) *Backend {
+	parsed, err := url.Parse(server.URL)
+	if err != nil {
+		log.Printf("Failed to parse server URL: %s\n", err)
+		return nil
+	}
+
+	u := parsed
+	h := time.Duration(server.HealthCheckTcpTimeout) * time.Millisecond
+	max := server.MaximalRequests
+	return NewBackend(u, h, max)
 }
 
 func (b *Backend) URL() *url.URL {

--- a/backend/serverPool.go
+++ b/backend/serverPool.go
@@ -88,7 +88,6 @@ func (p *ServerPool) AddServer(b *Backend) {
 	defer p.Unlock()
 	log.Printf("Adding server: %s\n", b.URL().String())
 	p.servers = append(p.servers, b)
-	p.Unlock()
 }
 
 func (p *ServerPool) RemoveServerByUrl(url *url.URL) error {

--- a/backend/serverPool.go
+++ b/backend/serverPool.go
@@ -90,11 +90,11 @@ func (p *ServerPool) AddServer(b *Backend) {
 	p.servers = append(p.servers, b)
 }
 
-func (p *ServerPool) RemoveServerByUrl(url *url.URL) error {
-	backends := p.servers
-
-	for k, v := range backends {
-		if v.URL().String() == url.String() {
+func (p *ServerPool) RemoveServerByUrl(url string) error {
+	p.Lock()
+	defer p.Unlock()
+	for k, v := range p.servers {
+		if v.URL().String() == url {
 			p.servers = append(p.servers[:k], p.servers[k+1:]...)
 			log.Printf("[%s] removed from server pool\n", url)
 			return nil

--- a/backend/serverPool.go
+++ b/backend/serverPool.go
@@ -84,6 +84,7 @@ func (p *ServerPool) GetCurrentServer() *Backend {
 }
 
 func (p *ServerPool) AddServer(b *Backend) {
+	log.Printf("Adding server: %s\n", b.URL().String())
 	p.servers = append(p.servers, b)
 }
 

--- a/backend/serverPool.go
+++ b/backend/serverPool.go
@@ -85,6 +85,7 @@ func (p *ServerPool) GetCurrentServer() *Backend {
 
 func (p *ServerPool) AddServer(b *Backend) {
 	p.Lock()
+	defer p.Unlock()
 	log.Printf("Adding server: %s\n", b.URL().String())
 	p.servers = append(p.servers, b)
 	p.Unlock()

--- a/backend/serverPool.go
+++ b/backend/serverPool.go
@@ -2,12 +2,9 @@ package backend
 
 import (
 	"errors"
-	"log"
-	"net/url"
-	"sync"
-	"time"
-
 	"github.com/pelageech/BDUTS/config"
+	"log"
+	"sync"
 )
 
 type ServerPool struct {
@@ -25,25 +22,10 @@ func NewServerPool() *ServerPool {
 	}
 }
 
-func (p *ServerPool) CreateBackend(server config.ServerConfig) *Backend {
-	parsed, err := url.Parse(server.URL)
-	if err != nil {
-		log.Printf("Failed to parse server URL: %s\n", err)
-		return nil
-	}
-
-	u := parsed
-	h := time.Duration(server.HealthCheckTcpTimeout) * time.Millisecond
-	max := server.MaximalRequests
-	b := NewBackend(u, h, max)
-
-	return b
-}
-
 func (p *ServerPool) ConfigureServerPool(servers []config.ServerConfig) {
 	for _, server := range servers {
 		log.Printf("%v", server)
-		if b := p.CreateBackend(server); b != nil {
+		if b := NewBackendConfig(server); b != nil {
 			p.AddServer(b)
 		}
 	}

--- a/backend/serverPool.go
+++ b/backend/serverPool.go
@@ -84,8 +84,10 @@ func (p *ServerPool) GetCurrentServer() *Backend {
 }
 
 func (p *ServerPool) AddServer(b *Backend) {
+	p.Lock()
 	log.Printf("Adding server: %s\n", b.URL().String())
 	p.servers = append(p.servers, b)
+	p.Unlock()
 }
 
 func (p *ServerPool) RemoveServerByUrl(url *url.URL) error {

--- a/backend/serverPool.go
+++ b/backend/serverPool.go
@@ -117,3 +117,11 @@ func (p *ServerPool) GetNextPeer() (*Backend, error) {
 
 	return nil, errors.New("all backends are turned down")
 }
+
+func (p *ServerPool) ServersURLs() []string {
+	var urls []string
+	for _, v := range p.Servers() {
+		urls = append(urls, v.URL().String())
+	}
+	return urls
+}

--- a/backend/serverPool.go
+++ b/backend/serverPool.go
@@ -96,6 +96,7 @@ func (p *ServerPool) RemoveServerByUrl(url *url.URL) error {
 	for k, v := range backends {
 		if v.URL().String() == url.String() {
 			p.servers = append(p.servers[:k], p.servers[k+1:]...)
+			log.Printf("[%s] removed from server pool\n", url)
 			return nil
 		}
 	}

--- a/lb/loadBalancer.go
+++ b/lb/loadBalancer.go
@@ -252,7 +252,7 @@ func (lb *LoadBalancer) AddServer(rw http.ResponseWriter, req *http.Request) {
 		http.Error(rw, err.Error(), http.StatusBadRequest)
 		return
 	}
-	b := lb.pool.CreateBackend(server)
+	b := backend.NewBackendConfig(server)
 	lb.pool.AddServer(b)
 	lb.healthCheckFunc(b)
 }

--- a/lb/loadBalancer.go
+++ b/lb/loadBalancer.go
@@ -215,7 +215,12 @@ ChooseServer:
 		server.SetAlive(false) // СДЕЛАТЬ СЧЁТЧИК ИЛИ ПОЧИТАТЬ КАК У НДЖИНКС
 		goto ChooseServer
 	}
-	defer resp.Body.Close()
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			log.Printf("[%s] %s", server.URL(), err)
+		}
+	}(resp.Body)
 
 	byteArray, err := backend.WriteBodyAndReturn(rw, resp)
 	if err != nil {

--- a/lb/loadBalancer.go
+++ b/lb/loadBalancer.go
@@ -256,3 +256,20 @@ func (lb *LoadBalancer) AddServer(rw http.ResponseWriter, req *http.Request) {
 	lb.pool.AddServer(b)
 	lb.healthCheckFunc(b)
 }
+
+func (lb *LoadBalancer) RemoveServer(rw http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodDelete {
+		http.Error(rw, "Only DELETE requests are supported", http.StatusMethodNotAllowed)
+		return
+	}
+
+	b := req.URL.Query().Get("backend")
+	if b == "" {
+		http.Error(rw, "Invalid request. No backend specified in the request URL.", http.StatusBadRequest)
+	}
+
+	err := lb.pool.RemoveServerByUrl(b)
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusNotFound)
+	}
+}

--- a/lb/loadBalancer.go
+++ b/lb/loadBalancer.go
@@ -254,4 +254,5 @@ func (lb *LoadBalancer) AddServer(rw http.ResponseWriter, req *http.Request) {
 	}
 	b := lb.pool.CreateBackend(server)
 	lb.pool.AddServer(b)
+	lb.healthCheckFunc(b)
 }

--- a/lb/loadBalancer.go
+++ b/lb/loadBalancer.go
@@ -241,6 +241,11 @@ func setLogPrefixBDUTS() {
 }
 
 func (lb *LoadBalancer) AddServer(rw http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		http.Error(rw, "Only POST requests are supported", http.StatusMethodNotAllowed)
+		return
+	}
+
 	var server config.ServerConfig
 	err := json.NewDecoder(req.Body).Decode(&server)
 	if err != nil {

--- a/lb/loadBalancer.go
+++ b/lb/loadBalancer.go
@@ -2,7 +2,9 @@ package lb
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
 	"log"
 	"net/http"
 	"time"
@@ -236,4 +238,15 @@ ChooseServer:
 
 func setLogPrefixBDUTS() {
 	log.SetPrefix("[BDUTS] ")
+}
+
+func (lb *LoadBalancer) AddServer(rw http.ResponseWriter, req *http.Request) {
+	var server config.ServerConfig
+	err := json.NewDecoder(req.Body).Decode(&server)
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusBadRequest)
+		return
+	}
+	b := lb.pool.CreateBackend(server)
+	lb.pool.AddServer(b)
 }

--- a/lb/loadBalancer.go
+++ b/lb/loadBalancer.go
@@ -275,3 +275,18 @@ func (lb *LoadBalancer) RemoveServer(rw http.ResponseWriter, req *http.Request) 
 		return
 	}
 }
+
+func (lb *LoadBalancer) GetServers(rw http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		http.Error(rw, "Only GET requests are supported", http.StatusMethodNotAllowed)
+		return
+	}
+
+	urls := lb.pool.ServersURLs()
+
+	err := json.NewEncoder(rw).Encode(urls)
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}

--- a/lb/loadBalancer.go
+++ b/lb/loadBalancer.go
@@ -266,10 +266,12 @@ func (lb *LoadBalancer) RemoveServer(rw http.ResponseWriter, req *http.Request) 
 	b := req.URL.Query().Get("backend")
 	if b == "" {
 		http.Error(rw, "Invalid request. No backend specified in the request URL.", http.StatusBadRequest)
+		return
 	}
 
 	err := lb.pool.RemoveServerByUrl(b)
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusNotFound)
+		return
 	}
 }

--- a/main.go
+++ b/main.go
@@ -162,6 +162,7 @@ func main() {
 	http.HandleFunc("/", loadBalancer.LoadBalancer)
 	http.HandleFunc("/favicon.ico", http.NotFound)
 	http.HandleFunc("/serverPool/add", loadBalancer.AddServer)
+	http.HandleFunc("/serverPool/remove", loadBalancer.RemoveServer)
 
 	// Config TLS: setting a pair crt-key
 	Crt, _ := tls.LoadX509KeyPair("MyCertificate.crt", "MyKey.key")

--- a/main.go
+++ b/main.go
@@ -163,6 +163,7 @@ func main() {
 	http.HandleFunc("/favicon.ico", http.NotFound)
 	http.HandleFunc("/serverPool/add", loadBalancer.AddServer)
 	http.HandleFunc("/serverPool/remove", loadBalancer.RemoveServer)
+	http.HandleFunc("/serverPool", loadBalancer.GetServers)
 
 	// Config TLS: setting a pair crt-key
 	Crt, _ := tls.LoadX509KeyPair("MyCertificate.crt", "MyKey.key")

--- a/main.go
+++ b/main.go
@@ -161,6 +161,7 @@ func main() {
 	// Serving
 	http.HandleFunc("/", loadBalancer.LoadBalancer)
 	http.HandleFunc("/favicon.ico", http.NotFound)
+	http.HandleFunc("/serverPool/add", loadBalancer.AddServer)
 
 	// Config TLS: setting a pair crt-key
 	Crt, _ := tls.LoadX509KeyPair("MyCertificate.crt", "MyKey.key")


### PR DESCRIPTION
Обычный запрос к лоадбалансеру:
```
GET / HTTP/1.1
Host: localhost:8080
Connection: close
User-Agent: RapidAPI/4.1.5 (Macintosh; OS X/13.3.0) GCDHTTPRequest
```

Добавление сервера в serverPool:
```
POST /serverPool/add HTTP/1.1
Content-Type: text/plain; charset=utf-8
Host: localhost:8080
Connection: close
User-Agent: RapidAPI/4.1.5 (Macintosh; OS X/13.3.0) GCDHTTPRequest
Content-Length: 94

{
  "url": "http://localhost:3037",
  "healthCheckTcpTimeout": 2000,
  "maximalRequests": 5
}
```

Получить список всех серверов в serverPool:
```
GET /serverPool HTTP/1.1
Host: localhost:8080
Connection: close
User-Agent: RapidAPI/4.1.5 (Macintosh; OS X/13.3.0) GCDHTTPRequest
```

Удалить сервер из serverPool:
```
DELETE /serverPool/remove?backend=http%3A%2F%2Flocalhost%3A3031 HTTP/1.1
Host: localhost:8080
Connection: close
User-Agent: RapidAPI/4.1.5 (Macintosh; OS X/13.3.0) GCDHTTPRequest
```



